### PR TITLE
Differentiate dark and bright black

### DIFF
--- a/snazzy.conf
+++ b/snazzy.conf
@@ -9,7 +9,7 @@ url_color             #0087BD
 
 # black
 color0   #282a36
-color8   #282a36
+color8   #686868
 
 # red
 color1   #FF5C57
@@ -37,4 +37,4 @@ color14  #9AEDFE
 
 # white
 color7   #F1F1F0
-color15  #F1F1F0
+color15  #EFF0EB


### PR DESCRIPTION
Having the same dark and bright black makes certain output appear invisible. 

The new colors respect the latest color definition in sindresorhus/hyper-snazzy: [bright black](https://github.com/sindresorhus/hyper-snazzy/blob/74ed92a79f64566262bfa44ba976041e2a49681e/index.js#L27), [bright white](https://github.com/sindresorhus/hyper-snazzy/blob/74ed92a79f64566262bfa44ba976041e2a49681e/index.js#L34).

Before:

<img src="https://user-images.githubusercontent.com/6376558/60144857-010a9180-9792-11e9-8ba9-c1b68c0430bd.png" width="249px">

After:

<img width="249px"  src="https://user-images.githubusercontent.com/6376558/60144874-11bb0780-9792-11e9-92da-555750c26bd3.png">