### PR TITLE
Add `cursor` color and `cursor_text_color`

### DIFF
--- a/snazzy.conf
+++ b/snazzy.conf
@@ -6,6 +6,8 @@ background            #282a36
 selection_foreground  #000000
 selection_background  #FFFACD
 url_color             #0087BD
+cursor                #97979B
+cursor_text_color     #282A36
 
 # black
 color0   #282a36


### PR DESCRIPTION
Closes https://github.com/connorholyday/kitty-snazzy/issues/5.
I took the cursor color from https://github.com/sindresorhus/hyper-snazzy/blob/f544d59f781bd4f510695c7dfeede40026b9a83c/index.js#L15. I realise, that it is very similar to kitty's default. Let me know if you prefer a different color.