### PR TITLE
Update selection foreground/background to be reverse foreground/background, and add theming for tabs and windows

### DIFF
--- a/snazzy.conf
+++ b/snazzy.conf
@@ -4,39 +4,39 @@
 foreground            #eff0eb
 background            #282a36
 selection_foreground  #000000
-selection_background  #FFFACD
-url_color             #0087BD
-cursor                #97979B
-cursor_text_color     #282A36
+selection_background  #fffacd
+url_color             #0087bd
+cursor                #97979b
+cursor_text_color     #282a36
 
 # black
 color0   #282a36
 color8   #686868
 
 # red
-color1   #FF5C57
-color9   #FF5C57
+color1   #ff5c57
+color9   #ff5c57
 
 # green
-color2   #5AF78E
-color10  #5AF78E
+color2   #5af78e
+color10  #5af78e
 
 # yellow
-color3   #F3F99D
-color11  #F3F99D
+color3   #f3f99d
+color11  #f3f99d
 
 # blue
-color4  #57C7FF
-color12 #57C7FF
+color4   #57c7ff
+color12  #57c7ff
 
 # magenta
-color5   #FF6AC1
-color13  #FF6AC1
+color5   #ff6ac1
+color13  #ff6ac1
 
 # cyan
-color6   #9AEDFE
-color14  #9AEDFE
+color6   #9aedfe
+color14  #9aedfe
 
 # white
-color7   #F1F1F0
-color15  #EFF0EB
+color7   #f1f1f0
+color15  #eff0eb

--- a/snazzy.conf
+++ b/snazzy.conf
@@ -3,8 +3,8 @@
 
 foreground            #eff0eb
 background            #282a36
-selection_foreground  #000000
-selection_background  #fffacd
+selection_foreground  #282a36
+selection_background  #eff0eb
 url_color             #0087bd
 cursor                #97979b
 cursor_text_color     #282a36

--- a/snazzy.conf
+++ b/snazzy.conf
@@ -1,13 +1,20 @@
 # Snazzy Colorscheme for Kitty
 # Based on https://github.com/sindresorhus/hyper-snazzy
 
-foreground            #eff0eb
-background            #282a36
-selection_foreground  #282a36
-selection_background  #eff0eb
-url_color             #0087bd
-cursor                #97979b
-cursor_text_color     #282a36
+foreground              #eff0eb
+background              #282a36
+selection_foreground    #282a36
+selection_background    #eff0eb
+cursor                  #97979b
+cursor_text_color       #282a36
+
+url_color               #0087bd
+active_border_color     #97979b
+inactive_border_color   #42434a
+active_tab_foreground   #282a36
+active_tab_background   #eff0eb
+inactive_tab_foreground #42434a
+inactive_tab_background #97979b
 
 # black
 color0   #282a36


### PR DESCRIPTION
Currently selection seems to use the default values in the kitty reference. This PR updates those to reverse foreground and background colors, which seems to be the intention in the hyper-snazzy theme (transparency is used because hyper terminal doesn't actually support setting foreground color). Also add theming for tabs and windows (splits).